### PR TITLE
Function rename and bug fix

### DIFF
--- a/services/segment-service.js
+++ b/services/segment-service.js
@@ -16,7 +16,7 @@ const config = {
 };
 
 /**
- * Adds a user by identifying them with either a userId or anonymousId, and optional traits.
+ * Adds user and or updates their traits by identifying them with their userId or anonymousId, plus any optional traits.
  * At least one of `userId` or `anonymousId` is required. The `traits` object can contain any key-value pair.
  *
  * @param {Object} params - The parameters object for adding a user.
@@ -26,7 +26,7 @@ const config = {
  *
  * @throws {Error} If neither `userId` nor `anonymousId` is provided.
  */
-function addUser({ userId, anonymousId, traits }) {
+function upsertUser({ userId, anonymousId, traits }) {
   try {
     if (!userId && !anonymousId) {
       throw new Error('Either `userId` or `anonymousId` must be provided.');
@@ -73,7 +73,9 @@ function addEvent({ userId, anonymousId, event, properties }) {
 async function getProfileTraits(userId) {
   try {
     const response = await axios.get(
-      `${baseURL}/spaces/${spaceID}/collections/users/profiles/user_id:${userId}/traits`,
+      `${baseURL}/spaces/${spaceID}/collections/users/profiles/user_id:${encodeURIComponent(
+        userId
+      )}/traits`,
       config
     );
 
@@ -96,7 +98,9 @@ async function getProfileTraits(userId) {
 async function getProfileEvents(userId) {
   try {
     const response = await axios.get(
-      `${baseURL}/spaces/${spaceID}/collections/users/profiles/user_id:${userId}/events`,
+      `${baseURL}/spaces/${spaceID}/collections/users/profiles/user_id:${encodeURIComponent(
+        userId
+      )}/events`,
       config
     );
 
@@ -155,7 +159,7 @@ function readProperties(jsonData, propertyList = null) {
 }
 
 module.exports = {
-  addUser,
+  upsertUser,
   addEvent,
   getProfileTraits,
   getProfileEvents,
@@ -164,7 +168,7 @@ module.exports = {
 
 /* Example usage:
 
-  addUser({
+  upsertUser({
     userId: '8967',
     traits: {
       name: 'John Black',

--- a/test/segmentService.test.js
+++ b/test/segmentService.test.js
@@ -1,6 +1,6 @@
 const setTimeout = require('timers/promises').setTimeout;
 const {
-  addUser,
+  upsertUser,
   addEvent,
   getProfileTraits,
   getProfileEvents,
@@ -9,10 +9,10 @@ const {
 require('dotenv').config();
 
 const stubbedData = {
-  userId: '123456789',
+  userId: '+1234567890',
   traits: {
     name: 'John Doe',
-    phone: '+123456789',
+    phone: '+1234567890',
     address: '123 Main St',
   },
   event: 'Pizza Ordered',
@@ -26,7 +26,7 @@ const stubbedData = {
 test('Expect A new user to be added and their profile traits retrieved', async () => {
   const { userId, traits, event, properties } = stubbedData;
 
-  addUser({ userId, traits });
+  upsertUser({ userId, traits });
   await setTimeout(15000);
 
   addEvent({ userId, event, properties });
@@ -40,7 +40,7 @@ test('Expect A new user to be added and their profile traits retrieved', async (
 test('Expect new user to be added and their events retrieved - array with objects containing requested properties', async () => {
   const { userId, traits, event, properties } = stubbedData;
 
-  addUser({ userId, traits });
+  upsertUser({ userId, traits });
   await setTimeout(15000);
 
   addEvent({ userId, event, properties });
@@ -62,7 +62,7 @@ test('Expect new user to be added and their events retrieved - array with object
 test('Expect new user to be added and their events retrieved - empty array returned as invalid property is requested', async () => {
   const { userId, traits, event, properties } = stubbedData;
 
-  addUser({ userId, traits });
+  upsertUser({ userId, traits });
   await setTimeout(15000);
 
   addEvent({ userId, event, properties });


### PR DESCRIPTION
This PR:    

1. Updates the name (and replaces it anywhere used) from `addUser` to `upsertUser` as this function can both add a user but also update their traits. Therefore this name was more appropriate

2. Fixes edge case where the userId needs to be URI Encoded for the situation where we pass along a phone number which could include the +1 which would currently break the fetch request. 

Testing.   

1. Have tested and updated the jest file to ensure the +1 and name changes all still successfully pass the tests.
2. 1. Dry ran the Twilio Phone-call 
3. Successfully was able to add a user to Segment 
4. After pre-populating some data to segment a second call was able to retrieve traits on a users profile. 
![Screenshot 2024-12-12 at 2 47 28 PM](https://github.com/user-attachments/assets/19ac3214-7f67-4941-b0a3-d032979a4ffb)
![Screenshot 2024-12-12 at 2 48 12 PM](https://github.com/user-attachments/assets/a4d028f1-869b-4bc0-bb1f-2449b41f3516)
