### PR TITLE
Enhancing error experience

### DIFF
--- a/services/segment-service.js
+++ b/services/segment-service.js
@@ -79,12 +79,20 @@ async function getProfileTraits(userId) {
       config
     );
 
-    const traits = response.data.traits;
-    console.log('getProfile: ', traits);
+    if (response.data.traits) {
+      const traits = response.data.traits;
+      console.log('getProfileTraits: ', traits);
+      return traits;
+    }
 
-    return traits;
+    return null;
   } catch (error) {
-    console.error('get_profile error:', error);
+    if (error.response.status === 404) {
+      console.log('User not found');
+    } else {
+      console.error('Error Occurred - :', error);
+    }
+
     return null;
   }
 }
@@ -104,12 +112,20 @@ async function getProfileEvents(userId) {
       config
     );
 
-    const data = response.data;
-    console.log('getEvents: ', data);
+    if (response.data) {
+      const data = response.data;
+      console.log('getProfileEvents: ', data);
+      return data;
+    }
 
-    return data;
+    return null;
   } catch (error) {
-    console.error('Error on Authentication or getting events:', error);
+    if (error.response.status === 404) {
+      console.log('User not found');
+    } else {
+      console.error('Error Occurred - :', error);
+    }
+
     return null;
   }
 }


### PR DESCRIPTION
When a user tries to get data on a profile that does not exist, this will suppress the full / native error statement and rather just log "user is not found" in the catch block.    
This is a common use case that could occur, and according to the doc found [here](https://segment.com/docs/unify/profile-api/#errors) it will always be a 404 on that type of issue.    

If it is not a 404 then we provide the entire error report in the log. 